### PR TITLE
feat(common): add functionality to query the nix config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 name = "common"
 version = "0.0.4"
 dependencies = [
+ "thiserror",
  "workspace-hack",
 ]
 
@@ -1945,6 +1946,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,7 +2361,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2511,6 +2532,9 @@ dependencies = [
  "either",
  "itertools",
  "phf_shared 0.11.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -10,3 +10,4 @@ publish = false
 
 [dependencies]
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+thiserror = "1"

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,3 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Christina Sørensen
 //
 // SPDX-License-Identifier: EUPL-1.2
+
+pub mod nix_conf;

--- a/crates/common/src/nix_conf.rs
+++ b/crates/common/src/nix_conf.rs
@@ -1,0 +1,266 @@
+// SPDX-FileCopyrightText: 2024 Christina Sørensen
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+//! Read `nix.conf` for settings
+
+use std::path::Path;
+
+use thiserror::Error;
+
+pub enum Value<'conf> {
+  /// Sets a conf value to this value
+  ///
+  /// e.g:
+  ///
+  /// ```conf
+  /// keep-outputs = true
+  /// ```
+  ///
+  /// Turns into:
+  ///
+  /// ```rust
+  /// Value::Set { key: "keep-outputs", value: "true" }
+  /// ```
+  Set { key: &'conf str, value: &'conf str },
+
+  /// Appends to a set value
+  ///
+  /// e.g:
+  ///
+  /// ```conf
+  /// substituters = a b
+  /// extra-substituters = c d
+  /// ```
+  ///
+  /// Turns into:
+  ///
+  /// ```rust
+  /// [
+  ///   Value::Set { key: "substituters", value: "a b" },
+  ///   Value::Append { key: "substituters", value: "c d" },
+  /// ]
+  /// ```
+  Append { key: &'conf str, value: &'conf str },
+
+  /// Includes another file (error if missing):
+  ///
+  /// e.g:
+  ///
+  /// ```conf
+  /// include path/to/file
+  /// ```
+  ///
+  /// Turns into:
+  ///
+  /// ```rust
+  /// Value::Include { path: std::path::Path::new("path/to/file") }
+  /// ```
+  Include { path: &'conf Path },
+
+  /// Includes another file if it exists:
+  ///
+  /// e.g:
+  ///
+  /// ```conf
+  /// !include path/to/file
+  /// ```
+  ///
+  /// Turns into:
+  ///
+  /// ```rust
+  /// Value::IncludeIfPresent { path: std::path::Path::new("path/to/file") }
+  /// ```
+  IncludeIfPresent { path: &'conf Path },
+}
+
+#[derive(Debug, Error)]
+#[error("configuration contained an invalid line: `{invalid_line}`")]
+pub struct LineError {
+  invalid_line: Box<str>,
+}
+
+#[derive(Debug, Error)]
+pub enum GetValueError {
+  #[error("configuration contained an invalid line: `{line}`")]
+  Invalid { line: Box<str> },
+
+  #[error("configuration contained an include to {} which wasn't resolved", path.display())]
+  UnresolvedInclude { path: Box<Path> },
+}
+
+#[derive(Debug, Error)]
+pub enum CliError {
+  #[error(transparent)]
+  FailedToRunCommand(std::io::Error),
+
+  #[error("command failed with code {status} and stderr:\n{stderr}")]
+  CommandFailed {
+    status: std::process::ExitStatus,
+    stderr: String,
+  },
+
+  #[error(transparent)]
+  InvalidUtf8(std::string::FromUtf8Error),
+}
+
+/// Fetch the configuration from `nix config show`
+///
+/// Requires `experimental-features = nix-command`
+pub fn nix_conf_from_cli() -> Result<String, CliError> {
+  // Invoke nix command
+  let std::process::Output {
+    status,
+    stdout,
+    stderr,
+  } = std::process::Command::new("nix")
+    .args(["conf", "show"])
+    .output()
+    .map_err(CliError::FailedToRunCommand)?;
+
+  // command failed
+  if !status.success() {
+    return Err(CliError::CommandFailed {
+      status,
+      stderr: String::from_utf8_lossy(&stderr).into_owned(),
+    });
+  }
+
+  // convert to string
+  String::from_utf8(stdout).map_err(CliError::InvalidUtf8)
+}
+
+/// Gets the value of a single key from the provided configuration.
+///
+/// **Warning:** we normalize the key values by removing the `extra-` prefix
+///
+/// It will perform value merging as appropriate, but it requires `conf` to have access to *all* set
+/// values in order to be correct:
+///
+/// ```conf
+/// # file-1.conf
+/// key = a
+/// extra-key = b
+/// include file-2.conf
+/// ```
+///
+/// ```conf
+/// # file-2.conf
+/// key = c
+/// extra-key = d
+/// ```
+///
+/// The real value is: `key = c b d`
+///
+/// `get_value(file-1.conf, "key") => Error include file-2.conf not resolved`
+/// `get_value(file-2.conf, "key") => c d`
+pub fn get_value(conf: &str, key: &str) -> Result<String, GetValueError> {
+  let values = conf
+    .lines()
+    .filter_map(|line| match parse_line(line) {
+      Ok(value) => match value? {
+        // key matches
+        value @ Value::Set {
+          key: key_,
+          value: _,
+        }
+        | value @ Value::Append {
+          key: key_,
+          value: _,
+        } if key_ == key => Some(Ok(value)),
+
+        // Key doesn't match
+        Value::Set { key: _, value: _ } | Value::Append { key: _, value: _ } => None,
+
+        // we don't resolve includes
+        Value::Include { path } | Value::IncludeIfPresent { path } => {
+          Some(Err(GetValueError::UnresolvedInclude { path: path.into() }))
+        }
+      },
+      Err(LineError { invalid_line }) => Some(Err(GetValueError::Invalid { line: invalid_line })),
+    })
+    .collect::<Result<Vec<Value>, GetValueError>>()?;
+
+  let mut final_value = String::new();
+
+  // find the Value::Set that was last in the config (latter value replace the previous one)
+  if let Some(value) = values.iter().rev().find_map(|value| match value {
+    Value::Set { key: _, value } => Some(value),
+    Value::Append { key: _, value: _ } => None,
+
+    // includes being present is an error
+    Value::Include { path: _ } | Value::IncludeIfPresent { path: _ } => unreachable!(),
+  }) {
+    final_value.push_str(value);
+  }
+
+  // append Value::Append values to the previous value
+  for value in values {
+    match value {
+      Value::Append { key: _, value } => {
+        // add a leading space to create a space separated list
+        if !final_value.is_empty() {
+          final_value.push(' ');
+        }
+
+        final_value.push_str(value);
+      }
+
+      // we already handled the Value::Set
+      Value::Set { key: _, value: _ } => continue,
+
+      // includes being present is an error
+      Value::Include { path: _ } | Value::IncludeIfPresent { path: _ } => unreachable!(),
+    }
+  }
+
+  Ok(final_value)
+}
+
+/// Parse a single line of a nix.conf configuration file
+fn parse_line(line: &str) -> Result<Option<Value>, LineError> {
+  // strip comments
+  let line = line
+    .split_once('#')
+    .map(|(line, _comment)| line)
+    .unwrap_or(line);
+
+  // strip extra whitesapce
+  let line = line.trim();
+
+  // return early on empty line
+  if line.is_empty() {
+    return Ok(None);
+  }
+
+  match line.split_once('=') {
+    // key = value pair
+    Some((key, value)) => {
+      // remove extra whitespace
+      let key = key.trim();
+      let value = value.trim();
+
+      // Are we appending to the previous value?
+      match key.strip_prefix("extra-") {
+        None => Ok(Some(Value::Set { key, value })),
+        Some(key) => Ok(Some(Value::Append { key, value })),
+      }
+    }
+
+    None => match line.split_once(' ') {
+      // include path
+      Some(("include", path)) => Ok(Some(Value::Include {
+        path: Path::new(path),
+      })),
+      // !include path
+      Some(("!include", path)) => Ok(Some(Value::IncludeIfPresent {
+        path: Path::new(path),
+      })),
+
+      // Invalid line
+      Some(_) | None => Err(LineError {
+        invalid_line: line.into(),
+      }),
+    },
+  }
+}

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -32,5 +32,8 @@ clap_builder = { version = "4", default-features = false, features = ["cargo", "
 either = { version = "1", default-features = false, features = ["use_std"] }
 itertools = { version = "0.12" }
 phf_shared = { version = "0.11", default-features = false, features = ["std"] }
+proc-macro2 = { version = "1" }
+quote = { version = "1" }
+syn = { version = "2", features = ["extra-traits", "full", "visit-mut"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
This allows us to tackle [issue #4] (nix cache detection).

This is intended to be used as follows:

```rust
use common::nix_conf;

// Helper that invokes `nix config show` and retrieves the stdout
let conf: String = nix_conf::nix_conf_get_from_cli().unwrap();

// Query the config for the "substituters" key (auto-merges extra-substituters, but it is not required)
let value: String = nix_conf::get_value(&conf, "substituters").unwrap();

// substituters is a list of URLs, parse the value like that
let substituters: Vec<&str> = value.split(' ').collect();
```

Some shortcuts were taken as we assume we are parsing `nix config show`'s output. Specifically:

- `include` and `!include` are not resolved.
- We don't query the `nix.conf` search path for where to find the configuration files
- We don't have functionality to parse the whole configuration (as only `substituters` is needed for [issue #4])

If the above mentioned complexity is needed I can implement it here or in a separate PR.

[issue #4]: https://git.fem.gg/cafkafk/nix-weather/issues/4